### PR TITLE
MOD#531 Remove cause of extraneous logging in mongo-connector

### DIFF
--- a/mongo_connector/oplog_manager.py
+++ b/mongo_connector/oplog_manager.py
@@ -332,12 +332,9 @@ class OplogThread(threading.Thread):
                                     if doc.get('renameCollection'):
                                         db = entry['ns'].split('.', 1)[0]
                                         db, coll = docman.command_helper.map_collection(db, doc['renameCollection'])
-                                        if doc and coll:
-                                            docman.handle_command(doc,
-                                                                  entry['ns'],
-                                                                  timestamp)
-                                    else:
-                                        docman.handle_command(doc,
+                                        if not doc or not coll:
+                                            continue
+                                    docman.handle_command(doc,
                                                           entry['ns'],
                                                           timestamp)
 

--- a/mongo_connector/oplog_manager.py
+++ b/mongo_connector/oplog_manager.py
@@ -329,7 +329,15 @@ class OplogThread(threading.Thread):
                                 elif operation == 'c':
                                     # use unmapped namespace
                                     doc = entry.get('o')
-                                    docman.handle_command(doc,
+                                    if doc.get('renameCollection'):
+                                        db = entry['ns'].split('.', 1)[0]
+                                        db, coll = docman.command_helper.map_collection(db, doc['renameCollection'])
+                                        if doc and coll:
+                                            docman.handle_command(doc,
+                                                                  entry['ns'],
+                                                                  timestamp)
+                                    else:
+                                        docman.handle_command(doc,
                                                           entry['ns'],
                                                           timestamp)
 


### PR DESCRIPTION
Do the check elastic2_doc_manager should do on operation ````renameCollection```` before throwing an exception